### PR TITLE
Empiricmdp io

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/learning/tabular/empiricmdp.py
+++ b/src/rlplg/learning/tabular/empiricmdp.py
@@ -214,8 +214,12 @@ def export_stats(
                 database.create_dataset(
                     f"{name}.{KREF_VALUES}", data=np.array(values, dtype=dtype)
                 )
-
-        tf.io.gfile.copy(src=tmp_file.name, dst=file_path, overwrite=overwrite)
+        try:
+            tf.io.gfile.copy(src=tmp_file.name, dst=file_path, overwrite=overwrite)
+        except tf.errors.OpError as err:
+            raise IOError(
+                f"Failed to export stats to {path}/{filename}.{FILE_EXT}"
+            ) from err
 
 
 def _flatten_mapping(

--- a/src/rlplg/learning/tabular/empiricmdp.py
+++ b/src/rlplg/learning/tabular/empiricmdp.py
@@ -282,11 +282,11 @@ def create_mdp_functions(mdp_stats: MdpStats) -> MdpFunctions:
     # only computes for visited states - so min visits = 1.
     for state_action, next_state_values in mdp_stats.transitions.items():
         state, action = state_action
-        max_visits = max(next_state_values.values())
+        total_visits = sum(next_state_values.values())
         for next_state, visits in next_state_values.items():
             entry_key = (state, action, next_state)
             # normalize visits
-            transitions[entry_key] = visits / max_visits
+            transitions[entry_key] = visits / total_visits
             # average rewards
             rewards[entry_key] = mdp_stats.rewards[state_action][next_state] / visits
     return MdpFunctions(transition=transitions, reward=rewards)

--- a/tests/rlplg/learning/tabular/test_empiricmdp.py
+++ b/tests/rlplg/learning/tabular/test_empiricmdp.py
@@ -1,3 +1,6 @@
+import tempfile
+import uuid
+
 import hypothesis
 import numpy as np
 from hypothesis import strategies as st
@@ -151,3 +154,16 @@ def test_create_mdp_functions():
     output = empiricmdp.create_mdp_functions(mdp_stats)
 
     assert output == expected
+
+
+def test_export_and_load_stats_roundtrip():
+    mdp_stats = empiricmdp.MdpStats(
+        transitions={(0, 0): {0: 8, 1: 2}, (1, 0): {1: 10}},
+        rewards={(0, 0): {0: -16.0, 1: -2.0}, (1, 0): {1: 0.0}},
+    )
+    path = tempfile.gettempdir()
+    filename = str(uuid.uuid4())
+    empiricmdp.export_stats(path, filename=filename, mdp_stats=mdp_stats)
+    output = empiricmdp.load_stats(path, filename)
+
+    assert output == mdp_stats

--- a/tests/rlplg/learning/tabular/test_empiricmdp.py
+++ b/tests/rlplg/learning/tabular/test_empiricmdp.py
@@ -180,3 +180,10 @@ def test_export_stats_with_bad_path():
 
     with pytest.raises(IOError):
         empiricmdp.export_stats(path, filename=filename, mdp_stats=mdp_stats)
+
+
+def test_load_stats_with_bad_path():
+    path = "unrealistic-path"
+    filename = str(uuid.uuid4())
+    with pytest.raises(IOError):
+        empiricmdp.load_stats(path, filename=filename)

--- a/tests/rlplg/learning/tabular/test_empiricmdp.py
+++ b/tests/rlplg/learning/tabular/test_empiricmdp.py
@@ -1,0 +1,139 @@
+import hypothesis
+import numpy as np
+from hypothesis import strategies as st
+
+from rlplg import envdesc
+from rlplg.learning.tabular import empiricmdp, policies
+from tests import defaults
+
+
+def test_inferred_mdp_init():
+    mdp_functions = empiricmdp.MdpFunctions(transition={}, reward={})
+    env_desc = envdesc.EnvDesc(num_states=0, num_actions=0)
+
+    inferred_mdp = empiricmdp.InferredMdp(
+        mdp_functions=mdp_functions, env_desc=env_desc
+    )
+
+    assert inferred_mdp.env_desc() == env_desc
+
+
+def test_inferred_mdp_transition_probability_with_defined_transitions():
+    transitions = {(0, 0, 0): 0.8, (0, 0, 1): 0.2, (1, 0, 1): 1.0}
+    mdp_functions = empiricmdp.MdpFunctions(transition=transitions, reward={})
+    env_desc = envdesc.EnvDesc(num_states=0, num_actions=0)
+
+    inferred_mdp = empiricmdp.InferredMdp(
+        mdp_functions=mdp_functions, env_desc=env_desc
+    )
+
+    assert inferred_mdp.transition_probability(0, 0, 0) == 0.8
+    assert inferred_mdp.transition_probability(0, 0, 1) == 0.2
+    assert inferred_mdp.transition_probability(1, 0, 1) == 1.0
+
+
+@hypothesis.given(
+    st.tuples(st.integers(), st.integers(), st.integers()).filter(
+        lambda x: x not in {(0, 0, 0), (0, 0, 1), (1, 0, 1)}
+    )
+)
+def test_inferred_mdp_transition_probability_with_undefined_transitions(
+    state_action_next_state,
+):
+    transitions = {(0, 0, 0): 0.8, (0, 0, 1): 0.2, (1, 0, 1): 1.0}
+    mdp_functions = empiricmdp.MdpFunctions(transition=transitions, reward={})
+    env_desc = envdesc.EnvDesc(num_states=0, num_actions=0)
+
+    inferred_mdp = empiricmdp.InferredMdp(
+        mdp_functions=mdp_functions, env_desc=env_desc
+    )
+    state, action, next_state = state_action_next_state
+    assert inferred_mdp.transition_probability(state, action, next_state) == 0.0
+
+
+def test_inferred_mdp_reward_with_defined_transitions():
+    rewards = {(0, 0, 0): -2.0, (0, 0, 1): -1.0, (1, 0, 1): 0.0}
+    mdp_functions = empiricmdp.MdpFunctions(transition={}, reward=rewards)
+    env_desc = envdesc.EnvDesc(num_states=0, num_actions=0)
+
+    inferred_mdp = empiricmdp.InferredMdp(
+        mdp_functions=mdp_functions, env_desc=env_desc
+    )
+
+    assert inferred_mdp.reward(0, 0, 0) == -2.0
+    assert inferred_mdp.reward(0, 0, 1) == -1.0
+    assert inferred_mdp.reward(1, 0, 1) == 0.0
+
+
+@hypothesis.given(
+    st.tuples(st.integers(), st.integers(), st.integers()).filter(
+        lambda x: x not in {(0, 0, 0), (0, 0, 1), (1, 0, 1)}
+    )
+)
+def test_inferred_mdp_reward_with_undefined_transitions(
+    state_action_next_state,
+):
+    rewards = {(0, 0, 0): -2.0, (0, 0, 1): -1.0, (1, 0, 1): 0.0}
+    mdp_functions = empiricmdp.MdpFunctions(transition={}, reward=rewards)
+    env_desc = envdesc.EnvDesc(num_states=0, num_actions=0)
+
+    inferred_mdp = empiricmdp.InferredMdp(
+        mdp_functions=mdp_functions, env_desc=env_desc
+    )
+    state, action, next_state = state_action_next_state
+    assert inferred_mdp.transition_probability(state, action, next_state) == 0.0
+
+
+def test_collect_mdp_stats():
+    environment = defaults.CountEnv()
+    mdp = defaults.CountEnvMDP()
+    policy = policies.PyRandomPolicy(
+        time_step_spec=environment.time_step_spec(),
+        action_spec=environment.action_spec(),
+        num_actions=mdp.env_desc().num_actions,
+    )
+
+    # (state,action) -> Mapping[next_state, visits]
+    output = empiricmdp.collect_mdp_stats(
+        environment=environment,
+        policy=policy,
+        state_id_fn=defaults.item,
+        action_id_fn=defaults.item,
+        num_episodes=100,
+        logging_frequency_episodes=1,
+    )
+    flattened_transitions = {
+        (state, action, next_state): visits
+        for ((state, action), next_states) in output.transitions.items()
+        for next_state, visits in next_states.items()
+    }
+    flattened_rewards = {
+        (state, action, next_state): rewards
+        for ((state, action), next_states) in output.rewards.items()
+        for next_state, rewards in next_states.items()
+    }
+
+    assert len(output.transitions) == len(output.rewards)
+    assert set(output.transitions.keys()) == set(output.rewards.keys())
+    assert len(flattened_transitions) == len(flattened_rewards)
+    # all visits counters are positive
+    assert np.sum(
+        (np.array(list(flattened_transitions.values())) > 0).astype(int)
+    ) == len(flattened_transitions)
+
+
+def test_aggregate_stats():
+    inputs = [
+        empiricmdp.MdpStats(
+            transitions={(0, 0): {0: 8, 1: 2}},
+            rewards={(0, 0): {0: -16.0, 1: -2.0}},
+        ),
+        empiricmdp.MdpStats(transitions={(1, 0): {1: 10}}, rewards={(1, 0): {1: 0.0}}),
+    ]
+    expected = empiricmdp.MdpStats(
+        transitions={(0, 0): {0: 8, 1: 2}, (1, 0): {1: 10}},
+        rewards={(0, 0): {0: -16.0, 1: -2.0}, (1, 0): {1: 0.0}},
+    )
+    output = empiricmdp.aggregate_stats(inputs)
+
+    assert output == expected

--- a/tests/rlplg/learning/tabular/test_empiricmdp.py
+++ b/tests/rlplg/learning/tabular/test_empiricmdp.py
@@ -137,3 +137,17 @@ def test_aggregate_stats():
     output = empiricmdp.aggregate_stats(inputs)
 
     assert output == expected
+
+
+def test_create_mdp_functions():
+    mdp_stats = empiricmdp.MdpStats(
+        transitions={(0, 0): {0: 8, 1: 2}, (1, 0): {1: 10}},
+        rewards={(0, 0): {0: -16.0, 1: -2.0}, (1, 0): {1: 0.0}},
+    )
+    expected = empiricmdp.MdpFunctions(
+        transition={(0, 0, 0): 0.8, (0, 0, 1): 0.2, (1, 0, 1): 1.0},
+        reward={(0, 0, 0): -2, (0, 0, 1): -1.0, (1, 0, 1): 0.0},
+    )
+    output = empiricmdp.create_mdp_functions(mdp_stats)
+
+    assert output == expected

--- a/tests/rlplg/learning/tabular/test_empiricmdp.py
+++ b/tests/rlplg/learning/tabular/test_empiricmdp.py
@@ -3,6 +3,7 @@ import uuid
 
 import hypothesis
 import numpy as np
+import pytest
 from hypothesis import strategies as st
 
 from rlplg import envdesc
@@ -167,3 +168,15 @@ def test_export_and_load_stats_roundtrip():
     output = empiricmdp.load_stats(path, filename)
 
     assert output == mdp_stats
+
+
+def test_export_stats_with_bad_path():
+    mdp_stats = empiricmdp.MdpStats(
+        transitions={(0, 0): {0: 8, 1: 2}, (1, 0): {1: 10}},
+        rewards={(0, 0): {0: -16.0, 1: -2.0}, (1, 0): {1: 0.0}},
+    )
+    path = "unrealistic-path"
+    filename = str(uuid.uuid4())
+
+    with pytest.raises(IOError):
+        empiricmdp.export_stats(path, filename=filename, mdp_stats=mdp_stats)


### PR DESCRIPTION
  - Casts io errors from tensorflow in empiric mdp to IOError
  - Adds tests for empiricmdp module
  - Fixes create_mdp_functions normalization of transition probabilities