### PR TITLE
Build: dependency linkage

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,6 +20,7 @@ click==8.1.3
 cloudpickle==2.2.1
     # via
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   gymnasium
 coverage[toml]==7.3.2
     # via
@@ -33,19 +34,23 @@ exceptiongroup==1.2.0
 farama-notifications==0.0.4
     # via
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   gymnasium
 ghp-import==2.1.0
     # via
     #   -r docs-requirements.txt
     #   mkdocs
 gymnasium==0.28.1
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   -r test-requirements.txt
 hypothesis==6.91.0
     # via -r test-requirements.txt
 importlib-metadata==6.0.0
     # via
     #   -r docs-requirements.txt
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   gymnasium
     #   markdown
     #   mkdocs
@@ -56,6 +61,7 @@ iniconfig==2.0.0
 jax-jumpy==1.0.0
     # via
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   gymnasium
 jinja2==3.1.2
     # via
@@ -81,6 +87,7 @@ mypy-extensions==1.0.0
 numpy==1.23.5
     # via
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   gymnasium
     #   jax-jumpy
     #   scipy
@@ -96,7 +103,9 @@ pathspec==0.11.2
     #   black
     #   mkdocs
 pillow==8.1.0
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   -r test-requirements.txt
 platformdirs==4.0.0
     # via
     #   -r docs-requirements.txt
@@ -126,7 +135,9 @@ pyyaml-env-tag==0.1
     #   -r docs-requirements.txt
     #   mkdocs
 scipy==1.10.1
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   -r test-requirements.txt
 six==1.16.0
     # via
     #   -r docs-requirements.txt
@@ -144,6 +155,7 @@ tomli==2.0.1
 typing-extensions==4.5.0
     # via
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   black
     #   gymnasium
 watchdog==2.3.1
@@ -154,4 +166,5 @@ zipp==3.15.0
     # via
     #   -r docs-requirements.txt
     #   -r requirements.txt
+    #   -r test-requirements.txt
     #   importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.1
+current_version = 0.17.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ CLASSIFIERS = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 META_FILE = read(META_PATH)

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,4 @@ setup(
     zip_safe=False,
     install_requires=read_requirements("requirements.in"),
     test_suite="tests",
-    tests_require=read_requirements("test-requirements.in"),
 )

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.17.1"
+__version__ = "0.17.2"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,3 +1,4 @@
+-r requirements.txt
 coverage>=7.2.1
 pytest>=7.2.1
 pytest-cov>=4.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,10 @@
 #
 attrs==22.2.0
     # via hypothesis
+cloudpickle==2.2.1
+    # via
+    #   -r requirements.txt
+    #   gymnasium
 coverage[toml]==7.3.2
     # via
     #   -r test-requirements.in
@@ -14,12 +18,34 @@ exceptiongroup==1.2.0
     # via
     #   hypothesis
     #   pytest
+farama-notifications==0.0.4
+    # via
+    #   -r requirements.txt
+    #   gymnasium
+gymnasium==0.28.1
+    # via -r requirements.txt
 hypothesis==6.91.0
     # via -r test-requirements.in
+importlib-metadata==6.0.0
+    # via
+    #   -r requirements.txt
+    #   gymnasium
 iniconfig==2.0.0
     # via pytest
+jax-jumpy==1.0.0
+    # via
+    #   -r requirements.txt
+    #   gymnasium
+numpy==1.23.5
+    # via
+    #   -r requirements.txt
+    #   gymnasium
+    #   jax-jumpy
+    #   scipy
 packaging==23.0
     # via pytest
+pillow==8.1.0
+    # via -r requirements.txt
 pluggy==1.0.0
     # via pytest
 pytest==7.4.3
@@ -28,9 +54,19 @@ pytest==7.4.3
     #   pytest-cov
 pytest-cov==4.1.0
     # via -r test-requirements.in
+scipy==1.10.1
+    # via -r requirements.txt
 sortedcontainers==2.4.0
     # via hypothesis
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
+typing-extensions==4.5.0
+    # via
+    #   -r requirements.txt
+    #   gymnasium
+zipp==3.15.0
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata


### PR DESCRIPTION
Makes `test-requirements` depend on `requirements` to avoid version conflicts