### PR TITLE
fix: get_state_id returns int instead of array

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.17.4
+current_version = 0.17.5
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.17.4"
+__version__ = "0.17.5"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/environments/randomwalk.py
+++ b/src/rlplg/environments/randomwalk.py
@@ -312,7 +312,7 @@ def get_state_id(observation: Mapping[str, Any]) -> int:
     """
     Computes an integer ID that represents that state.
     """
-    state_id: int = observation[OBS_KEY_POSITION]
+    state_id: int = observation[OBS_KEY_POSITION].item()
     return state_id
 
 


### PR DESCRIPTION
Makes is serializable for eval functions