### PR TITLE
Perf: towerhanoi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.3
+current_version = 0.18.4
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.18.3"
+__version__ = "0.18.4"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/environments/towerhanoi.py
+++ b/src/rlplg/environments/towerhanoi.py
@@ -247,9 +247,7 @@ def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, floa
         move_penalty = -1.0
         reward = 0.0
         # move top disk from source to dest
-        mutable_state = list(state)
-        mutable_state[pegs[source][0]] = dest
-        new_observation[OBS_KEY_STATE] = tuple(mutable_state)
+        new_observation[OBS_KEY_STATE] = state[:pegs[source][0]] + (dest,) + state[pegs[source][0]+1:]
     return new_observation, move_penalty + reward
 
 


### PR DESCRIPTION
Performance tweaks to make the env fast.

Time reduction for 1M calls to `env.step` TowerOfHanoi > 15s to 11s.

```
import timeit

from rlplg import envsuite

ENV_SPECS = [
    {"name": "TowerOfHanoi", "args": {"num_disks": 6}},
]

def setup_benchmark(spec):
    env_spec = envsuite.load(spec["name"], **spec["args"])
    env = env_spec.environment
    env.reset()

    def go():
        env.step(0)
    return go

if __name__ == "__main__":
    for spec in ENV_SPECS:
        fn = setup_benchmark(spec)
        ts = timeit.timeit(fn)
        print(f"Time for 1M executions: {spec['name']} > {ts}s")
    
```

