### PR TITLE
Perf tune

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.4
+current_version = 0.18.5
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.18.4"
+__version__ = "0.18.5"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/core.py
+++ b/src/rlplg/core.py
@@ -6,7 +6,18 @@ import abc
 import base64
 import dataclasses
 import hashlib
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    SupportsInt,
+    Tuple,
+    Union,
+)
 
 import gymnasium as gym
 import numpy as np
@@ -143,7 +154,7 @@ class MdpDiscretizer:
         """
 
     @abc.abstractmethod
-    def action(self, action: Any) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """

--- a/src/rlplg/environments/abcseq.py
+++ b/src/rlplg/environments/abcseq.py
@@ -41,7 +41,7 @@ Notes:
 """
 
 import copy
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -160,12 +160,12 @@ class ABCSeqMdpDiscretizer(core.MdpDiscretizer):
         del self
         return get_state_id(observation)
 
-    def action(self, action: Any) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def apply_action(

--- a/src/rlplg/environments/abcseq.py
+++ b/src/rlplg/environments/abcseq.py
@@ -165,8 +165,7 @@ class ABCSeqMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def apply_action(

--- a/src/rlplg/environments/gridworld.py
+++ b/src/rlplg/environments/gridworld.py
@@ -22,7 +22,7 @@ import numpy as np
 from gymnasium import spaces
 from PIL import Image as image
 
-from rlplg import core, npsci
+from rlplg import core
 from rlplg.core import InitState, MutableEnvTransition, RenderType, TimeStep
 
 ENV_NAME = "GridWorld"
@@ -241,8 +241,7 @@ class GridWorldMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 class GridWorldRenderer:

--- a/src/rlplg/environments/gridworld.py
+++ b/src/rlplg/environments/gridworld.py
@@ -15,7 +15,7 @@ import os
 import os.path
 import sys
 import time
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Mapping, Optional, Sequence, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -236,12 +236,12 @@ class GridWorldMdpDiscretizer(core.MdpDiscretizer):
         """
         return self.__state_fn(observation)
 
-    def action(self, action: int) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 class GridWorldRenderer:

--- a/src/rlplg/environments/iceworld.py
+++ b/src/rlplg/environments/iceworld.py
@@ -18,7 +18,7 @@ import contextlib
 import copy
 import io
 import sys
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Mapping, Optional, Sequence, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -237,12 +237,12 @@ class IceWorldMdpDiscretizer(core.MdpDiscretizer):
         _, cols = size
         return row * cols + col
 
-    def action(self, action: int) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def create_envspec_from_map(

--- a/src/rlplg/environments/iceworld.py
+++ b/src/rlplg/environments/iceworld.py
@@ -25,7 +25,7 @@ import numpy as np
 from gymnasium import spaces
 from PIL import Image as image
 
-from rlplg import core, npsci
+from rlplg import core
 from rlplg.core import InitState, MutableEnvTransition, RenderType, TimeStep
 
 ENV_NAME = "IceWorld"
@@ -242,8 +242,7 @@ class IceWorldMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def create_envspec_from_map(

--- a/src/rlplg/environments/randomwalk.py
+++ b/src/rlplg/environments/randomwalk.py
@@ -14,7 +14,7 @@ Combined with a random policy, it should produce the same effect.
 
 import copy
 import math
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -193,12 +193,12 @@ class StateRandomWalkMdpDiscretizer(core.MdpDiscretizer):
         del self
         return get_state_id(observation)
 
-    def action(self, action: int) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/environments/randomwalk.py
+++ b/src/rlplg/environments/randomwalk.py
@@ -20,7 +20,7 @@ import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
-from rlplg import core, npsci
+from rlplg import core
 from rlplg.core import InitState, MutableEnvTransition, RenderType, TimeStep
 
 ENV_NAME = "StateRandomWalk"
@@ -198,8 +198,7 @@ class StateRandomWalkMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/environments/redgreen.py
+++ b/src/rlplg/environments/redgreen.py
@@ -17,7 +17,7 @@ zero for terminal state.
 """
 
 import copy
-from typing import Any, Mapping, Optional, Sequence, Tuple
+from typing import Any, Mapping, Optional, Sequence, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -152,12 +152,12 @@ class RedGreenMdpDiscretizer(core.MdpDiscretizer):
         del self
         return get_state_id(observation)
 
-    def action(self, action: int) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/environments/redgreen.py
+++ b/src/rlplg/environments/redgreen.py
@@ -23,7 +23,7 @@ import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
-from rlplg import core, npsci
+from rlplg import core
 from rlplg.core import InitState, MutableEnvTransition, RenderType, TimeStep
 
 ENV_NAME = "RedGreenSeq"
@@ -157,8 +157,7 @@ class RedGreenMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/environments/towerhanoi.py
+++ b/src/rlplg/environments/towerhanoi.py
@@ -27,7 +27,7 @@ Code based on https://github.com/xadahiya/toh-gym.
 import collections
 import copy
 import functools
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, List, Mapping, Optional, Sequence, SupportsInt, Tuple
 
 import gymnasium as gym
 import numpy as np
@@ -174,12 +174,12 @@ class TowerOfHanoiMdpDiscretizer(core.MdpDiscretizer):
         del self
         return get_state_id(observation)
 
-    def action(self, action: int) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/environments/towerhanoi.py
+++ b/src/rlplg/environments/towerhanoi.py
@@ -33,7 +33,7 @@ import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
-from rlplg import combinatorics, core, npsci
+from rlplg import combinatorics, core
 from rlplg.core import InitState, MutableEnvTransition, RenderType, TimeStep
 
 ENV_NAME = "TowerOfHanoi"
@@ -179,8 +179,7 @@ class TowerOfHanoiMdpDiscretizer(core.MdpDiscretizer):
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def apply_action(observation: Mapping[str, Any], action: int) -> Tuple[Any, float]:

--- a/src/rlplg/envsuite.py
+++ b/src/rlplg/envsuite.py
@@ -10,7 +10,7 @@ import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
-from rlplg import core, npsci
+from rlplg import core
 from rlplg.core import EnvTransition
 from rlplg.environments import (
     abcseq,
@@ -48,16 +48,14 @@ class DefaultGymEnvMdpDiscretizer(core.MdpDiscretizer):
         Maps an observation to a state ID.
         """
         del self
-        state_: int = npsci.item(observation)
-        return state_
+        return observation
 
     def action(self, action: Any) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        action_: int = npsci.item(action)
-        return action_
+        return action
 
 
 def load(name: str, **args) -> core.EnvSpec:

--- a/src/rlplg/envsuite.py
+++ b/src/rlplg/envsuite.py
@@ -4,7 +4,7 @@ defined in either `rlplg` or gymnasium.
 """
 
 import functools
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, SupportsInt
 
 import gymnasium as gym
 import numpy as np
@@ -43,19 +43,19 @@ class DefaultGymEnvMdpDiscretizer(core.MdpDiscretizer):
     Creates an environment discrete maps for states and actions.
     """
 
-    def state(self, observation: Any) -> int:
+    def state(self, observation: SupportsInt) -> int:
         """
         Maps an observation to a state ID.
         """
         del self
-        return observation
+        return int(observation)
 
-    def action(self, action: Any) -> int:
+    def action(self, action: SupportsInt) -> int:
         """
         Maps an agent action to an action ID.
         """
         del self
-        return action
+        return int(action)
 
 
 def load(name: str, **args) -> core.EnvSpec:

--- a/src/rlplg/learning/tabular/policies.py
+++ b/src/rlplg/learning/tabular/policies.py
@@ -168,7 +168,7 @@ class PyEpsilonGreedyPolicy(core.PyPolicy):
             seed=seed,
         )
         self.epsilon = epsilon
-        self._rng = random.Random(seed=seed)
+        self._rng = random.Random(seed)
 
     def get_initial_state(self, batch_size: Optional[int] = None) -> Any:
         del batch_size

--- a/src/rlplg/learning/tabular/policies.py
+++ b/src/rlplg/learning/tabular/policies.py
@@ -4,6 +4,7 @@ This module contains implemenation for certain discrete arm policies.
 
 import copy
 import dataclasses
+import random
 from typing import Any, Callable, Optional, Protocol
 
 import numpy as np
@@ -37,9 +38,9 @@ class PyRandomPolicy(core.PyPolicy, SupportsStateActionProbability):
     ):
         super().__init__(emit_log_probability=emit_log_probability, seed=seed)
         self._num_actions = num_actions
-        self._arms = np.arange(start=0, stop=num_actions)
+        self._arms = tuple(range(self._num_actions))
         self._uniform_chance = np.array(1.0) / np.array(num_actions, dtype=np.float32)
-        self._rng = np.random.default_rng(seed=seed)
+        self._rng = random.Random(seed)
 
     def get_initial_state(self, batch_size: Optional[int] = None) -> Any:
         del batch_size
@@ -167,7 +168,7 @@ class PyEpsilonGreedyPolicy(core.PyPolicy):
             seed=seed,
         )
         self.epsilon = epsilon
-        self._rng = np.random.default_rng(seed=seed)
+        self._rng = random.Random(seed=seed)
 
     def get_initial_state(self, batch_size: Optional[int] = None) -> Any:
         del batch_size


### PR DESCRIPTION
Reduce execution time by:
 - Using efficient sampling
 - Reducing overhead in discretizers


Timing before
```sh
Time for 1M executions: ABCSeq > 28.786020657978952s
Time for 1M executions: CliffWalking-v0 > 43.7704252419644s
Time for 1M executions: FrozenLake-v1 > 45.51855944900308s
Time for 1M executions: GridWorld > 29.24034555099206s
Time for 1M executions: RedGreenSeq > 25.887435415002983s
Time for 1M executions: StateRandomWalk > 37.23643843003083s
Time for 1M executions: IceWorld > 35.839821477013174s
Time for 1M executions: IceWorld > 33.02065679198131s
Time for 1M executions: Taxi-v3 > 53.802538334042765s
Time for 1M executions: TowerOfHanoi > 36.17664202704327s
```

Timing after
```sh
Time for 1M executions: ABCSeq > 6.206487336952705s
Time for 1M executions: CliffWalking-v0 > 19.736388417019043s
Time for 1M executions: FrozenLake-v1 > 22.389855408051517s
Time for 1M executions: GridWorld > 7.742409807047807s
Time for 1M executions: RedGreenSeq > 5.973983867967036s
Time for 1M executions: StateRandomWalk > 7.521410243993159s
Time for 1M executions: IceWorld > 9.817344871989917s
Time for 1M executions: IceWorld > 8.382971332001034s
Time for 1M executions: Taxi-v3 > 27.488373774976935s3
Time for 1M executions: TowerOfHanoi > 13.601569910999388s
```


```python
@profile
def setup_benchmark(spec):
    env_spec = envsuite.load(spec["name"], **spec["args"])
    env = env_spec.environment
    policy = policies.PyRandomPolicy(num_actions=env_spec.mdp.env_desc.num_actions)
    obs, _ = env.reset()
    table = {}
    @profile
    def go():
        nonlocal obs
        policy_step = policy.action(obs)
        state_id = env_spec.discretizer.state(obs)
        action_id = env_spec.discretizer.action(policy_step.action)
        obs, rr, term, trunc, _ = env.step(policy_step.action)
        table[(state_id, action_id)] = rr
        if term or trunc:
            obs, _ = env.reset()
    return go
```