### PR TITLE
Extern egreedy policy in control algorithms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.5
+current_version = 0.19.6
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.19.5"
+__version__ = "0.19.6"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/learning/tabular/policies.py
+++ b/src/rlplg/learning/tabular/policies.py
@@ -144,7 +144,7 @@ class PyQGreedyPolicy(core.PyPolicy):
         """
         Overrides q-table.
         """
-        self._state_action_value_table = copy.deepcopy(action_values)
+        self._state_action_value_table = action_values
 
 
 class PyEpsilonGreedyPolicy(core.PyPolicy):

--- a/src/rlplg/learning/tabular/policies.py
+++ b/src/rlplg/learning/tabular/policies.py
@@ -140,6 +140,12 @@ class PyQGreedyPolicy(core.PyPolicy):
             info=policy_info,
         )
 
+    def set_action_values(self, action_values: np.ndarray) -> None:
+        """
+        Overrides q-table.
+        """
+        self._state_action_value_table = copy.deepcopy(action_values)
+
 
 class PyEpsilonGreedyPolicy(core.PyPolicy):
     """

--- a/src/rlplg/learning/tabular/policycontrol.py
+++ b/src/rlplg/learning/tabular/policycontrol.py
@@ -111,7 +111,7 @@ def onpolicy_sarsa_control(
             )
             # update the qtable before generating the
             # next step in the trajectory
-            setattr(egreedy_policy.exploit_policy, "_state_action_value_table", qtable)
+            egreedy_policy.exploit_policy.set_action_values(qtable)
             steps_counter += 1
             step += 1
 
@@ -205,7 +205,7 @@ def onpolicy_qlearning_control(
             )
             # update the qtable before generating the
             # next step in the trajectory
-            setattr(egreedy_policy.exploit_policy, "_state_action_value_table", qtable)
+            egreedy_policy.exploit_policy.set_action_values(qtable)
             steps_counter += 1
             step += 1
 
@@ -322,11 +322,7 @@ def onpolicy_nstep_sarsa_control(
                 )
                 # update the qtable before generating the
                 # next step in the trajectory
-                setattr(
-                    egreedy_policy.exploit_policy,
-                    "_state_action_value_table",
-                    qtable,
-                )
+                egreedy_policy.exploit_policy.set_action_values(qtable)
                 steps_counter += 1
             step += 1
         # need to copy qtable because it's a mutable numpy array

--- a/src/rlplg/learning/utils.py
+++ b/src/rlplg/learning/utils.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.typing import DTypeLike
 
 from rlplg import core
+from rlplg.learning.tabular import policies
 
 
 def policy_prob_fn(policy: core.PyPolicy, traj: core.TrajectoryStep) -> float:
@@ -75,3 +76,15 @@ def nan_or_inf(array: Union[np.ndarray, int, float]) -> bool:
     is_nan: bool = np.any(np.isnan(array)).item()
     is_inf: bool = np.any(np.isinf(array)).item()
     return is_nan or is_inf
+
+
+def create_egreedy_policy(
+    initial_qtable: np.ndarray, state_id_fn: Callable[[Any], int], epsilon: float
+) -> policies.PyEpsilonGreedyPolicy:
+    return policies.PyEpsilonGreedyPolicy(
+        policy=policies.PyQGreedyPolicy(
+            state_id_fn=state_id_fn, action_values=initial_qtable
+        ),
+        num_actions=initial_qtable.shape[1],
+        epsilon=epsilon,
+    )


### PR DESCRIPTION
By creating the policy in the functions, this limits the kinds of policies that can be learned.

The goal there is to enable other policies, specifically options policies, to be used for control
This PR also defines a public API to update the q-table in a greedy policy