### PR TITLE
Refactor: set value of terminal states to zero in learning functions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.9
+current_version = 0.19.10
 commit = True
 tag = True
 

--- a/src/rlplg/__init__.py
+++ b/src/rlplg/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "guilherme"
-__version__ = "0.19.9"
+__version__ = "0.19.10"
 __email__ = "guilherme@dsv.su.se"
 __description__ = "RL-Playground"
 __uri__ = "https://github.com/guidj/rlplg"

--- a/src/rlplg/learning/tabular/policycontrol.py
+++ b/src/rlplg/learning/tabular/policycontrol.py
@@ -106,11 +106,14 @@ def onpolicy_sarsa_control(
             next_state_id = state_id_fn(experiences[step + 1].observation)
             next_action_id = action_id_fn(experiences[step + 1].action)
             alpha = lrs(episode=episode, step=steps_counter)
-            qtable[state_id, action_id] += alpha * (
-                reward
-                + gamma * qtable[next_state_id, next_action_id]
-                - qtable[state_id, action_id]
-            )
+            if experiences[step].terminated:
+                qtable[state_id, action_id] = 0.0
+            else:
+                qtable[state_id, action_id] += alpha * (
+                    reward
+                    + gamma * qtable[next_state_id, next_action_id]
+                    - qtable[state_id, action_id]
+                )
             # update the qtable before generating the
             # next step in the trajectory
             egreedy_policy.exploit_policy.set_action_values(qtable)
@@ -189,11 +192,14 @@ def onpolicy_qlearning_control(
             alpha = lrs(episode=episode, step=steps_counter)
             # Q-learning uses the next best action's
             # value
-            qtable[state_id, action_id] += alpha * (
-                reward
-                + gamma * np.max(qtable[next_state_id])
-                - qtable[state_id, action_id]
-            )
+            if experiences[step].terminated:
+                qtable[state_id, action_id] = 0.0
+            else:
+                qtable[state_id, action_id] += alpha * (
+                    reward
+                    + gamma * np.max(qtable[next_state_id])
+                    - qtable[state_id, action_id]
+                )
             # update the qtable before generating the
             # next step in the trajectory
             egreedy_policy.exploit_policy.set_action_values(qtable)
@@ -297,9 +303,12 @@ def onpolicy_nstep_sarsa_control(
                 state_id = state_id_fn(experiences[tau].observation)
                 action_id = action_id_fn(experiences[tau].action)
                 alpha = lrs(episode=episode, step=steps_counter)
-                qtable[state_id, action_id] += alpha * (
-                    nstep_returns - qtable[state_id, action_id]
-                )
+                if experiences[tau].terminated:
+                    qtable[state_id, action_id] = 0.0
+                else:
+                    qtable[state_id, action_id] += alpha * (
+                        nstep_returns - qtable[state_id, action_id]
+                    )
                 # update the qtable before generating the
                 # next step in the trajectory
                 egreedy_policy.exploit_policy.set_action_values(qtable)


### PR DESCRIPTION
As per theoretical spec.
It would be more accurate to know which states are terminal
and set their values to zero.
As is, unvisited states will have the value provided as an
initial value